### PR TITLE
Fixed issue #3: add Wavefront event when user deployed new function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavefront-serverless-rollback-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Auto rollback plugin integrated with Wavefront",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavefront-serverless-rollback-plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Auto rollback plugin integrated with Wavefront",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Every new deployment will trigger Wavefront event with name "<service_name> deployed" and has <service_name> as its source/host